### PR TITLE
[Fix] 메인화면 향수 추천 슬라이싱

### DIFF
--- a/Scenchive/src/main/java/com/example/scenchive/domain/filter/controller/PerfumeController.java
+++ b/Scenchive/src/main/java/com/example/scenchive/domain/filter/controller/PerfumeController.java
@@ -91,9 +91,9 @@ public class PerfumeController {
 
     //메인 화면 : 토큰과 계절 Id를 넘겨주면 추천 향수 리스트를 반환
     @GetMapping("recommend")
-    public List<PersonalDto> getPerfumesByUserAndSeason(@RequestParam("season") Long seasonId){
+    public List<MainPerfumeDto> getPerfumesByUserAndSeason(@RequestParam("season") Long seasonId){
         Long userId=memberRepository.findByEmail(memberService.getMyUserWithAuthorities().getEmail()).get().getId();
-        List<PersonalDto> mainRecommends=personalService.getPerfumesByUserAndSeason(userId, seasonId);
+        List<MainPerfumeDto> mainRecommends=personalService.getPerfumesByUserAndSeason(userId, seasonId);
         return mainRecommends;
     }
 

--- a/Scenchive/src/main/java/com/example/scenchive/domain/filter/dto/MainPerfumeDto.java
+++ b/Scenchive/src/main/java/com/example/scenchive/domain/filter/dto/MainPerfumeDto.java
@@ -1,0 +1,22 @@
+package com.example.scenchive.domain.filter.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MainPerfumeDto {
+    private Long id; // 향수 id
+    private String perfumeName; // 향수 이름
+    private String brandName; // 브랜드 이름
+    private List<Long> keywordIds; // 키워드 id 리스트
+    private double ratingAvg; //향수 리뷰 평점평균
+
+    public MainPerfumeDto(Long id, String perfumeName, String brandName, List<Long> keywordIds, double ratingAvg) {
+        this.id = id;
+        this.perfumeName = perfumeName;
+        this.brandName = brandName;
+        this.keywordIds = keywordIds;
+        this.ratingAvg = ratingAvg;
+    }
+}

--- a/Scenchive/src/main/java/com/example/scenchive/domain/filter/repository/PerfumeRepository.java
+++ b/Scenchive/src/main/java/com/example/scenchive/domain/filter/repository/PerfumeRepository.java
@@ -10,4 +10,6 @@ public interface PerfumeRepository extends JpaRepository<Perfume, Long> {
     List<Perfume> findByPerfumeNameContainingIgnoreCase(String perfumeName);
 
     List<Perfume> findByBrandId(Long brandId);
+
+
 }


### PR DESCRIPTION
## 📌관련 이슈
<!--  closed #Issue_number -->
- #24 

## ✨Task 내용
<!--  작업한 코드 내용 적기 -->
- 향수 정보에 리뷰데이터를 기반으로 한 평점평균 정보를 추가하였습니다.
- 메인화면에서 보여주는 추천 향수를 별점순으로 정렬해 상위 3개만 보여주도록 하였습니다.

## 📑비고
