### PR TITLE
[Fix] 메인화면 향수 추천 기능 수정

### DIFF
--- a/Scenchive/src/main/java/com/example/scenchive/domain/filter/dto/MainPerfumeDto.java
+++ b/Scenchive/src/main/java/com/example/scenchive/domain/filter/dto/MainPerfumeDto.java
@@ -11,16 +11,16 @@ public class MainPerfumeDto {
     private String perfumeImage; // 향수 이미지
     private String brandName; // 브랜드 이름
     private String brandName_kr; // 브랜드 이름 (한글)
-    private List<Long> keywordIds; // 키워드 id 리스트
+    //private List<Long> keywordIds; // 키워드 id 리스트
     private double ratingAvg; //향수 리뷰 평점평균
 
-    public MainPerfumeDto(Long id, String perfumeName, String perfumeImage, String brandName, String brandName_kr, List<Long> keywordIds, double ratingAvg) {
+    public MainPerfumeDto(Long id, String perfumeName, String perfumeImage, String brandName, String brandName_kr, double ratingAvg) {
         this.id = id;
         this.perfumeName = perfumeName;
         this.perfumeImage = perfumeImage;
         this.brandName = brandName;
         this.brandName_kr = brandName_kr;
-        this.keywordIds = keywordIds;
+       // this.keywordIds = keywordIds;
         this.ratingAvg = ratingAvg;
     }
 }


### PR DESCRIPTION
## 📌관련 이슈
<!--  closed #Issue_number -->
- #24 

## ✨Task 내용
<!--  작업한 코드 내용 적기 -->
- 메인화면 추천 향수 목록 정렬 기준을 수정함
- 먼저 겹치는 키워드 개수가 많은 향수 순으로 정렬하고 겹치는 키워드 개수가 같은 향수들 내에서는 별점순으로 정렬함

## 📑비고
