### PR TITLE
[Fix] 향수 프로필 댓글 조회 기능 수정

### DIFF
--- a/Scenchive/src/main/java/com/example/scenchive/domain/comment/dto/MyCommentDto.java
+++ b/Scenchive/src/main/java/com/example/scenchive/domain/comment/dto/MyCommentDto.java
@@ -3,14 +3,22 @@ package com.example.scenchive.domain.comment.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 public class MyCommentDto {
-    private Long id;
-    private String content;
+    private Long commentId;
+    private String commentContent;
+    private Long boardId;
+    private String boardTitle;
+    private LocalDateTime commentModifiedAt;
 
-    public MyCommentDto(Long id, String content) {
-        this.id = id;
-        this.content = content;
+    public MyCommentDto(Long commentId, String commentContent, Long boardId, String boardTitle, LocalDateTime commentModifiedAt) {
+        this.commentId = commentId;
+        this.commentContent = commentContent;
+        this.boardId = boardId;
+        this.boardTitle = boardTitle;
+        this.commentModifiedAt = commentModifiedAt;
     }
 }

--- a/Scenchive/src/main/java/com/example/scenchive/domain/member/service/MyContentService.java
+++ b/Scenchive/src/main/java/com/example/scenchive/domain/member/service/MyContentService.java
@@ -42,7 +42,7 @@ public class MyContentService {
         }
 
         for (Comment comment : comments) {
-            MyCommentDto commentDto = new MyCommentDto(comment.getId(), comment.getContent());
+            MyCommentDto commentDto = new MyCommentDto(comment.getId(), comment.getContent(), comment.getBoard().getId(), comment.getBoard().getTitle(), comment.getModified_at());
             commentDtos.add(commentDto);
         }
 


### PR DESCRIPTION
## 📌관련 이슈
<!--  closed #Issue_number -->

## ✨Task 내용
<!--  작업한 코드 내용 적기 -->
- 프로필 댓글 조회 반환값에 댓글이 달린 게시글의 id값과 제목, 댓글 수정 일시 추가.

## 📑비고
