### PR TITLE
Feat: 마이페이지 닉네임 중복 조회 및 수정

### DIFF
--- a/Scenchive/src/main/java/com/example/scenchive/domain/member/controller/MemberController.java
+++ b/Scenchive/src/main/java/com/example/scenchive/domain/member/controller/MemberController.java
@@ -59,6 +59,7 @@ public class MemberController {
 //        return memberService.checkName(checkNameDto);
 //    }
 
+    // 회원가입 시 닉네임 중복 조회
     @PostMapping("/member/name")
     public ResponseEntity<String> checkName(@Valid @RequestBody CheckNameDto checkNameDto){
         String result = memberService.checkName(checkNameDto);

--- a/Scenchive/src/main/java/com/example/scenchive/domain/member/service/MemberService.java
+++ b/Scenchive/src/main/java/com/example/scenchive/domain/member/service/MemberService.java
@@ -65,6 +65,7 @@ public class MemberService {
         return "사용 가능한 이메일입니다.";
     }
 
+    // 회원가입 용 닉네임 중복 확인
     @Transactional
     public String checkName(CheckNameDto checkNameDto){
         if (memberRepository.findByName(checkNameDto.getName()).orElse(null) != null) {

--- a/Scenchive/src/main/java/com/example/scenchive/domain/member/service/ProfileService.java
+++ b/Scenchive/src/main/java/com/example/scenchive/domain/member/service/ProfileService.java
@@ -143,10 +143,15 @@ public class ProfileService {
         return "update";
     }
 
-    //향수 프로필: 닉네임 변경
+    // 마이페이지용 닉네임 중복 확인
+    public boolean isNameAvailable(String name){
+        return !memberRepository.existsByName(name);
+    }
+
+    // 마이페이지용 닉네임 변경
     @Transactional
     public String changeName(Long userId, CheckNameDto checkNameDto){
-        if (memberRepository.findByName(checkNameDto.getName()).orElse(null) != null) {
+        if(!isNameAvailable(checkNameDto.getName())){
             return "이미 존재하는 닉네임입니다.";
         }
         Member member = memberRepository.findById(userId).get();


### PR DESCRIPTION
## 📌관련 이슈
<!--  closed #Issue_number -->
#158 
## ✨Task 내용
<!--  작업한 코드 내용 적기 -->
- 마이페이지, 회원가입용 닉네임 중복 조회 분리
- 마이페이지 : 토큰 필요
- 회원가입 : 토큰 불필요
## 📑비고
